### PR TITLE
Handled FB login failure with an app re-render

### DIFF
--- a/src/components/facebook/FacebookLoginButton.tsx
+++ b/src/components/facebook/FacebookLoginButton.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
 import ReactFacebookLogin from "react-facebook-login";
 
-export const FacebookLogin = ({onFacebookLoginComplete}) => <ReactFacebookLogin
+export const FacebookLogin = ({onFacebookLoginComplete, onFacebookLoginFailure}) => <ReactFacebookLogin
     appId="1010813445640879"
     autoLoad={false}
     fields="name,email,picture"
     callback={onFacebookLoginComplete} 
-/>
+    onFailure={onFacebookLoginFailure} />

--- a/src/components/facebook/FacebookLoginLogout.tsx
+++ b/src/components/facebook/FacebookLoginLogout.tsx
@@ -3,8 +3,12 @@ import { FacebookLogin } from "./FacebookLoginButton";
 import { FacebookLoggedInButton } from "./FacebookLoggedInButton";
 
 export const FacebookLoginLogout = (props) => {
-    const {facebookUserSession, onFacebookLoginComplete, onLogoutRequested} = props;
+    const {facebookUserSession, onFacebookLoginComplete, onFacebookLoginFailure, onLogoutRequested} = props;
     return facebookUserSession
         ? <FacebookLoggedInButton {...props} />
+<<<<<<< HEAD
         : <FacebookLogin {...{onFacebookLoginComplete}} />
+=======
+        : <FacebookLogin {...{onFacebookLoginComplete, onFacebookLoginFailure}} /> 
+>>>>>>> Handled FB login failure with an app re-render
 }

--- a/src/components/facebook/FacebookLoginLogout.tsx
+++ b/src/components/facebook/FacebookLoginLogout.tsx
@@ -6,9 +6,5 @@ export const FacebookLoginLogout = (props) => {
     const {facebookUserSession, onFacebookLoginComplete, onFacebookLoginFailure, onLogoutRequested} = props;
     return facebookUserSession
         ? <FacebookLoggedInButton {...props} />
-<<<<<<< HEAD
-        : <FacebookLogin {...{onFacebookLoginComplete}} />
-=======
         : <FacebookLogin {...{onFacebookLoginComplete, onFacebookLoginFailure}} /> 
->>>>>>> Handled FB login failure with an app re-render
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,6 +16,7 @@ const renderApp = (state) => {
     window.onresize = () => {
         renderApp(state);
     }
+
     const navigateToSimpleModel = () => renderApp({...state, showSimpleModel: true});
     const onFacebookLoginComplete = (facebookUserSession) => {
         Cookies.set(facebookUserSessionCookieKey, facebookUserSession);
@@ -46,6 +47,13 @@ const renderApp = (state) => {
         });
     }
 
+    const onFacebookLoginFailure = () => {
+        alert("Failed!");
+        renderApp({
+            ...state
+        });
+    }
+
     const statefulController = StatefulController(renderApp, state);
     const statefulControllerByProperty = StatefulControllerByProperty(statefulController);
     const castleRiskController = statefulControllerByProperty('castleRisk', CastleRiskInitialState);
@@ -58,7 +66,8 @@ const renderApp = (state) => {
         onSideNavCollapseRequested,
         onHamburgerClicked,
         onCelebrationXClicked,
-        CastleRisk: castleRiskController(CastleRisk)
+        CastleRisk: castleRiskController(CastleRisk),
+        onFacebookLoginFailure
     }
 
     ReactDOM.render(
@@ -75,6 +84,7 @@ const isLocalhost = () => window.location.hostname == "localhost";
 const developers = ['tom@tommysullivan.me','mrcorn123@yahoo.com','tastulae@mail.usf.edu',"aashreya.isforever@gmail.com", 'patmetsch@roadrunner.com']
 const isDeveloper = facebookUserSession => facebookUserSession && developers.includes(facebookUserSession.email);
 const inDevMode = isLocalhost() || isDeveloper(facebookUserSession);
+
 
 const initialState = {
     showSimpleModel: false, 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -48,7 +48,6 @@ const renderApp = (state) => {
     }
 
     const onFacebookLoginFailure = () => {
-        alert("Failed!");
         renderApp({
             ...state
         });


### PR DESCRIPTION
Utilized `react-facebook-login`'s included `onFailure` event listener to call for an app re-render when the user closes the FB login dialogue without logging in.