### PR TITLE
Deconstrcted Celebration notice

### DIFF
--- a/src/components/layouts/CelebrationModal.tsx
+++ b/src/components/layouts/CelebrationModal.tsx
@@ -1,0 +1,90 @@
+import * as React from 'react';
+
+import { HPModal } from './HPModal';
+import Button from '@material-ui/core/Button';
+import Confetti from 'react-confetti';
+import FavoriteIconTwoTone from '@material-ui/icons/FavoriteBorderTwoTone';
+import RedeemIconOutlined from '@material-ui/icons/RedeemOutlined';
+import StroreIconOutlined from '@material-ui/icons/StoreOutlined';
+import LockIconOutlined from '@material-ui/icons/LockOutlined';
+
+export const confettiStyle = {
+    "position": "absolute",
+    "top": "0",
+    "left": "0",
+    "width": "100%",
+    "height": "100%"
+}
+
+export const actionContainerStyle = {
+    "background-color": "#E9E9E9",
+    "border-radius": "25px",
+    "padding": "10px",
+    "margin": "0 auto",
+}
+
+export const actionIconContainerStyle = {
+    "width": "100%",
+    "display": "inline-block",
+}
+
+export const actionButtonStyle = {
+    "margin": "8px",
+    "background-color": "rgba(255,0,0,0.5)",
+}
+
+export interface ICelebrationModalProps {
+    onXClicked(): void,
+    numHeartpointsAwarded: number
+}
+
+export const CelebrationModal = (props:ICelebrationModalProps) => { 
+    const { innerWidth:width, innerHeight:height } = window;
+    const numberOfPieces = width * height / 3638.4;
+    const confettiProps = {
+        width,
+        height,
+        numberOfPieces,
+        gravity: 0.3,
+        style: confettiStyle
+    }
+    const subtitleText:string = "You have been awarded " + props.numHeartpointsAwarded;
+
+    return(
+        <React.Fragment>
+            <Confetti {...confettiProps} />
+            <HPModal
+                title="Congratulations!"
+                subtitle={subtitleText}
+                imageURL="images/Celebration.png" 
+                onXClicked={props.onXClicked}>
+                    <div style={actionContainerStyle}>
+                        <h4>What you can do: </h4>
+                        <div style={actionIconContainerStyle}>
+                            <Button
+                                style={actionButtonStyle}
+                                size={'large'}
+                                variant={'contained'}>
+                                <RedeemIconOutlined />
+                                <h5>&nbsp; Give It</h5>
+                            </Button>
+                            <Button
+                                style={actionButtonStyle}
+                                size={'large'}
+                                variant={'contained'}>
+                                <StroreIconOutlined />
+                                <h5>&nbsp; Use It</h5>
+                            </Button>
+                            <Button
+                                style={actionButtonStyle}
+                                size={'large'}
+                                variant={'contained'}>
+                                <LockIconOutlined />
+                                <h5>&nbsp; Keep It</h5>
+                            </Button>
+                        </div>
+                    </div>
+            </HPModal>
+        </React.Fragment>
+    )
+}

--- a/src/components/layouts/CelebrationModal.tsx
+++ b/src/components/layouts/CelebrationModal.tsx
@@ -48,14 +48,19 @@ export const CelebrationModal = (props:ICelebrationModalProps) => {
         gravity: 0.3,
         style: confettiStyle
     }
-    const subtitleText:string = "You have been awarded " + props.numHeartpointsAwarded;
 
     return(
         <React.Fragment>
             <Confetti {...confettiProps} />
             <HPModal
                 title="Congratulations!"
-                subtitle={subtitleText}
+                subtitle={
+                    <h3 style={{fontSize: "1.5vw"}}>
+                        You have been awarded &nbsp;  
+                        <FavoriteIconTwoTone />
+                        {props.numHeartpointsAwarded}
+                    </h3>
+                }
                 imageURL="images/Celebration.png" 
                 onXClicked={props.onXClicked}>
                     <div style={actionContainerStyle}>

--- a/src/components/layouts/HPModal.tsx
+++ b/src/components/layouts/HPModal.tsx
@@ -19,7 +19,7 @@ export const modalHeaderStyle = {
 
 export interface IHPModalProps{
     title: string,
-    subtitle: string,
+    subtitle: React.ReactNode,
     imageURL: string,
     children: React.ReactNode,
     onXClicked(): void,

--- a/src/components/layouts/HPModal.tsx
+++ b/src/components/layouts/HPModal.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import Modal from '@material-ui/core/Modal';
+import ClearIconRounded from '@material-ui/icons/ClearOutlined';
+
+export const modalForgroundStyle = {
+    "margin": "50px auto 0",
+    "padding": "25px",
+    "width": "50%",
+    "background-color": "#FFFFFF",
+    "border-radius": "10px",
+    "text-align": "center",
+}
+
+export const modalHeaderStyle = {
+    "margin-top": "0px",
+    "font-size": "4vw",
+    "color": "rgba(255,0,0,0.5)",
+}
+
+export interface IHPModalProps{
+    title: string,
+    subtitle: string,
+    imageURL: string,
+    children: React.ReactNode,
+    onXClicked(): void,
+}
+
+export const HPModal = (props:IHPModalProps) => {
+    return(
+        <Modal
+            open={true}
+            disableAutoFocus={true}>
+            <div style={modalForgroundStyle}>
+                <ClearIconRounded onClick={props.onXClicked} style={{float: "right"}}/>
+                <h1 style={{clear: "both", marginTop: "0px", fontSize: "4vw", color: "rgba(255,0,0,0.5)"}}>
+                    {props.title}
+                </h1>
+                <h3 style={{fontSize: "1.5vw"}}>
+                    {props.subtitle}
+                </h3>
+                <img 
+                    style={{width: "50%", margin: "12px 0"}} 
+                    src={props.imageURL} />
+                {props.children}
+            </div>
+        </Modal>
+    )
+}

--- a/src/components/layouts/Site.tsx
+++ b/src/components/layouts/Site.tsx
@@ -8,7 +8,8 @@ import { Theme } from "../../style/theme";
 import { CssBaseline, withStyles } from "@material-ui/core";
 import { TopNav } from "../nav/TopNav";
 import { SideNav } from "../nav/SideNav";
-import { Celebration } from "./Celebration";
+import { Celebration } from './Celebration';
+import { CelebrationModal } from "./CelebrationModal";
 import { FacebookLoginLogout } from "../facebook/FacebookLoginLogout";
 import classNames from 'classnames';
 
@@ -28,7 +29,7 @@ export const SiteWithoutStyle = (props) => {
                     <Route path="/castleRisk" component={routerProps => <div><CastleRisk {...routerProps} {...props}/><CastleRisk {...routerProps} {...props} /></div>} />
                     <Route component={NotFound} />
                 </Switch>    
-                { shouldShowCelebration && <Celebration numHeartpointsAwarded={10} onXClicked={onCelebrationXClicked} /> }
+                { shouldShowCelebration && <CelebrationModal numHeartpointsAwarded={10} onXClicked={onCelebrationXClicked} /> }
             </MuiThemeProvider>
             </main>
             </div>


### PR DESCRIPTION
**//---WORK IN PROGRESS PR ---//**

Broke Celebration notice down into two components:

- The reusable HPModal.tsx

- CelebrationModal.tsx,

 which is composed of an HPModal and the passed `props.children`.

This will allow for easily maintaining continuity between, and permitting extensive variation among all existing and forthcoming modals used within the HeartPoints.org site.

There are a few kinks I still have to figure out, but I figured you could take a look and tell me if I'm on the right track.

Thanks!