### PR TITLE
Quickfix https www forwarding bug

### DIFF
--- a/src/cicd/unitTest.sh
+++ b/src/cicd/unitTest.sh
@@ -36,6 +36,8 @@ hp_onTestComplete() { local failureOrSuccess=$1
 }
 
 hp_test() { local baseUrl=$1
+    #TODO: If curl fails, output is captured but this script continues, yielding false positive
+
     echo "Testing..."
     echo "Test homepage html file is 200..."
     echo "$(curl -L --insecure "${baseUrl}" --fail -o /dev/null)"
@@ -46,7 +48,7 @@ hp_test() { local baseUrl=$1
     echo "passed"
     echo "" 
     echo "Test commitSha presence in header matches current sha ($(git_currentSha)):"
-    local headerOutput="$(curl -L --insecure -I "${baseUrl}?preventCache=$(date +%s)")"
+    local headerOutput="$(curl -L --fail --insecure -I "${baseUrl}?preventCache=$(date +%s)")"
     echo "$headerOutput"
     if echo "$headerOutput" | grep -i "commitSha: $(git_currentSha)"; then
         hp_onTestComplete "passed"

--- a/src/utils/maybe/AllMaybes.ts
+++ b/src/utils/maybe/AllMaybes.ts
@@ -8,7 +8,7 @@ export type AllMaybes = <T>(maybes: Maybes<T>) => IMaybe<T>;
 
 export const allMaybes:AllMaybes = 
     <T> (maybes: Maybes<T>) =>
-    typesafeEntries(maybes).every(([key, value]) => value.hasValue) 
+    typesafeEntries(maybes).every(([key, value]) => value.hasValue()) 
         ? Some(typesafeEntries(maybes).reduce(
             (obj, [key, value]) => ({...obj, [key]: value.value}),
             {}

--- a/src/webServer/middleware/immutableMiddlewares.ts
+++ b/src/webServer/middleware/immutableMiddlewares.ts
@@ -1,7 +1,5 @@
 import { commitShaHeaderMiddleware } from "./commitShaHeaderMiddleware";
-// import { loadBalancerHttpRedirector } from "./loadBalancerHttpRedirector";
+import { loadBalancerHttpRedirector } from "./loadBalancerHttpRedirector";
 import { requestLogMiddleware } from "./requestLogMiddleware";
 
-//todo: fix loadBalancerHttpRedirector and re-add
-// export const immutableMiddlewares = [requestLogMiddleware, commitShaHeaderMiddleware, loadBalancerHttpRedirector];
-export const immutableMiddlewares = [requestLogMiddleware, commitShaHeaderMiddleware];
+export const immutableMiddlewares = [requestLogMiddleware, commitShaHeaderMiddleware, loadBalancerHttpRedirector];

--- a/src/webServer/middleware/immutableMiddlewares.ts
+++ b/src/webServer/middleware/immutableMiddlewares.ts
@@ -1,5 +1,7 @@
 import { commitShaHeaderMiddleware } from "./commitShaHeaderMiddleware";
-import { loadBalancerHttpRedirector } from "./loadBalancerHttpRedirector";
+// import { loadBalancerHttpRedirector } from "./loadBalancerHttpRedirector";
 import { requestLogMiddleware } from "./requestLogMiddleware";
 
-export const immutableMiddlewares = [requestLogMiddleware, commitShaHeaderMiddleware, loadBalancerHttpRedirector];
+//todo: fix loadBalancerHttpRedirector and re-add
+// export const immutableMiddlewares = [requestLogMiddleware, commitShaHeaderMiddleware, loadBalancerHttpRedirector];
+export const immutableMiddlewares = [requestLogMiddleware, commitShaHeaderMiddleware];


### PR DESCRIPTION
mike, the deploy went out, the headers were actually not present by the time the request hit the pod, so it didn't work.

further, there was a bug in the allMaybes code that called `hasValue` instead of `hasValue()` so it was truthy, because it was a defined method, even tho had we actually called `hasValue()` sometimes it would return false (such as when the extra LB headers are not there), so at least then the middleware should just pass the request thru to `next()`

...why the headers are not there i don't know, but i see that fact in our k8s pod logs viewer:
https://console.cloud.google.com/logs/viewer?interval=PT1H&project=heartpoints-org&minLogLevel=0&expandAll=false&timestamp=2019-09-29T06:38:45.486000000Z&customFacets=&limitCustomFacetWidth=true&advancedFilter=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22heartpoints-org%22%0Aresource.labels.location%3D%22us-central1-a%22%0Aresource.labels.cluster_name%3D%22heartpoints-org%22%0Aresource.labels.namespace_name%3D%22default%22%0Aresource.labels.pod_name%3D%22heartpoints-org-676fc4595f-s7j28%22%0A&scrollTimestamp=2019-09-29T06:36:10.268840836Z&dateRangeStart=2019-09-29T05:38:45.796Z&dateRangeEnd=2019-09-29T06:38:45.796Z&resource=k8s_cluster