### PR TITLE
Delete Current Volunteering Opportunity

### DIFF
--- a/src/cicd/git.sh
+++ b/src/cicd/git.sh
@@ -67,6 +67,7 @@ hp_git() { local args="${@:-}"
 hp_g() { local message="$@"
     hp_git add -A
     hp_git commit -m "${message}"
+    hp_git push origin head
 }
 
 git_currentShaOrTempShaIfDirty() {

--- a/src/frontEnd/homePage/HomePage.tsx
+++ b/src/frontEnd/homePage/HomePage.tsx
@@ -9,7 +9,7 @@ const containerStyle = {
     alignItems: "center"
 }
 
-export const HomePage = ({shouldShowSnackbar}) => { 
+export const HomePage = ({shouldShowSnackbar, snackbarText}) => { 
     return <Container style={containerStyle}>
         <Card style={{textAlign: "center", verticalAlign: "middle"}}>
             <img width="100%" src="/images/logo.png" />
@@ -20,6 +20,6 @@ export const HomePage = ({shouldShowSnackbar}) => {
             </Typography>
             <Space />
         </Card>
-        {shouldShowSnackbar && <MiscSnackBar msg="Organization Deleted" />}
+        {shouldShowSnackbar && <MiscSnackBar msg={snackbarText} />}
     </Container>
 }

--- a/src/frontEnd/modals/initialModalsState.ts
+++ b/src/frontEnd/modals/initialModalsState.ts
@@ -1,4 +1,5 @@
 export const initialModalsState = () => ({
     shouldShowCelebration: false,
-    shouldShowSnackbar: false
+    shouldShowSnackbar: false,
+    snackbarText: ""
 })

--- a/src/frontEnd/organizations/react/LoadedOrganization.tsx
+++ b/src/frontEnd/organizations/react/LoadedOrganization.tsx
@@ -72,7 +72,7 @@ export const LoadedOrganization = ({ creatorEmail, title, mission, imageThumbnai
         {shouldShowDialog && 
             <YesOrNoDialog 
                 isOpen={shouldShowDialog} 
-                titleText="Delete This Organization?" 
+                titleText={`Delete ${title}?`} 
                 onYesClicked={confirmOrgDelete} 
                 onNoClicked={cancelOrgDelete} />
         }

--- a/src/frontEnd/organizations/react/LoadedOrganization.tsx
+++ b/src/frontEnd/organizations/react/LoadedOrganization.tsx
@@ -38,7 +38,7 @@ export const LoadedOrganization = ({ creatorEmail, title, mission, imageThumbnai
     const [shouldShowDialog, toggleDialog] = useState(false);
 
     const confirmOrgDelete = () => {
-        deleteOrganization(href);
+        deleteOrganization(href, title);
     }
 
     const cancelOrgDelete = () => {

--- a/src/frontEnd/organizations/reducers/deleteOrganization.ts
+++ b/src/frontEnd/organizations/reducers/deleteOrganization.ts
@@ -7,7 +7,8 @@ export const deleteOrganization = (state, organizationToDelete) => {
     const stateWithoutDeletedOrg = {
         ...state,
         organizations: orgsWithSpecifiedOrgDeleted,
-        shouldShowSnackbar: true
+        shouldShowSnackbar: true,
+        snackbarText: "Organization Deleted"
     };
 
     return navTo(stateWithoutDeletedOrg, "/");

--- a/src/frontEnd/organizations/reducers/deleteOrganization.ts
+++ b/src/frontEnd/organizations/reducers/deleteOrganization.ts
@@ -1,14 +1,14 @@
 import { navTo } from "../../nav/navTo";
 import { Organizations } from "../data/Organizations";
 
-export const deleteOrganization = (state, organizationToDelete) => {
+export const deleteOrganization = (state, organizationToDelete, title) => {
     const orgs:Organizations = state.organizations;
     const orgsWithSpecifiedOrgDeleted = orgs.filter((org) => org.href != organizationToDelete);
     const stateWithoutDeletedOrg = {
         ...state,
         organizations: orgsWithSpecifiedOrgDeleted,
         shouldShowSnackbar: true,
-        snackbarText: "Organization Deleted"
+        snackbarText:  `${title} Deleted`
     };
 
     return navTo(stateWithoutDeletedOrg, "/");

--- a/src/frontEnd/organizations/reducers/orgCallbacks.ts
+++ b/src/frontEnd/organizations/reducers/orgCallbacks.ts
@@ -1,7 +1,9 @@
 import { addNewOrganization } from "./addNewOrganization";
 import { deleteOrganization } from "./deleteOrganization";
+import { deleteOpportunity } from "../../volunteering/reducers/deleteOpportunity";
 
 export const orgCallbacks = () => ({
     addNewOrganization,
     deleteOrganization,
+    deleteOpportunity
 })

--- a/src/frontEnd/volunteering/LoadVolunteeringOption.tsx
+++ b/src/frontEnd/volunteering/LoadVolunteeringOption.tsx
@@ -11,7 +11,7 @@ import { DeleteButton } from '../buttons/DeleteButton';
 import { YesOrNoDialog } from '../modals/YesOrNoDialog';
 import { inDevMode } from '../developers/inDevMode';
 
-export const LoadVolunteeringOption = ({creatorEmail, imageThumbnailURL, title, href, jobTitle, jobDescription, navTo, deleteOpportunity, facebookUserSession}) => {
+export const LoadVolunteeringOption = ({creatorEmail, imageThumbnailURL, title, href, jobTitle, jobDescription, navTo, deleteOpportunity, facebookUserSession, jobID}) => {
 
     const userEmail = facebookUserSession ? facebookUserSession.email : "";
     const userIsCreator = userEmail == creatorEmail || inDevMode();
@@ -19,7 +19,7 @@ export const LoadVolunteeringOption = ({creatorEmail, imageThumbnailURL, title, 
     const [shouldShowDialog, toggleDialog] = useState(false);
 
     const confirmOppDelete = () => {
-        deleteOpportunity(href, jobTitle);
+        deleteOpportunity(jobTitle, jobID);
     }
 
     const cancelOppDelete = () => {

--- a/src/frontEnd/volunteering/LoadVolunteeringOption.tsx
+++ b/src/frontEnd/volunteering/LoadVolunteeringOption.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {Grid, Typography} from '@material-ui/core';
 import { Space } from '../page/Space';
 import { Image } from "../forms/viewEditToggleables/Image";
@@ -7,8 +7,25 @@ import { EditButton } from '../buttons/EditButton';
 import { defaultOrgLogoSrc } from '../organizations/data/defaultOrgLogoSrc';
 import { Page } from '../page/Page';
 import { HPButton } from '../forms/HPButton';
+import { DeleteButton } from '../buttons/DeleteButton';
+import { YesOrNoDialog } from '../modals/YesOrNoDialog';
 
-export const LoadVolunteeringOption = ({creatorEmail, imageThumbnailURL, title, href, jobTitle, jobDescription, navTo}) => {
+export const LoadVolunteeringOption = ({creatorEmail, imageThumbnailURL, title, href, jobTitle, jobDescription, navTo, deleteOpportunity}) => {
+
+    const [shouldShowDialog, toggleDialog] = useState(false);
+
+    const confirmOppDelete = () => {
+        deleteOpportunity(href, jobTitle);
+    }
+
+    const cancelOppDelete = () => {
+        toggleDialog(false);
+    }
+
+    const deleteCurrentOpportunityRequested = () => {
+        toggleDialog(true);
+    }
+
     return(
         <Page>
             <Grid container direction="row" justify="flex-start" alignItems="center" spacing={2}>
@@ -16,8 +33,9 @@ export const LoadVolunteeringOption = ({creatorEmail, imageThumbnailURL, title, 
                     <Image field={{value: imageThumbnailURL || defaultOrgLogoSrc}} isEditMode={false} />
                 </Grid>
                 <Grid item>
-                    <PageTitle>
-                        {jobTitle} 
+                    <PageTitle>{jobTitle} 
+                        <EditButton {...{navTo, onClick: () => alert(href)}} />
+                        <DeleteButton onClick={deleteCurrentOpportunityRequested} />
                     </PageTitle>
                     <Space />
                     <Typography variant="h6">
@@ -30,6 +48,12 @@ export const LoadVolunteeringOption = ({creatorEmail, imageThumbnailURL, title, 
             <Typography variant="body1"><strong>Job Description:</strong> {jobDescription}</Typography>
             <Space />
             <Typography variant="caption" style={{color: "lightgray"}}>Created by: {creatorEmail}</Typography>
+            { shouldShowDialog && 
+                <YesOrNoDialog 
+                    isOpen={shouldShowDialog}
+                    titleText="Delete Volunteering Opportunity?"
+                    onYesClicked={confirmOppDelete}
+                    onNoClicked={cancelOppDelete} />}
         </Page>
     );
 }

--- a/src/frontEnd/volunteering/LoadVolunteeringOption.tsx
+++ b/src/frontEnd/volunteering/LoadVolunteeringOption.tsx
@@ -9,8 +9,12 @@ import { Page } from '../page/Page';
 import { HPButton } from '../forms/HPButton';
 import { DeleteButton } from '../buttons/DeleteButton';
 import { YesOrNoDialog } from '../modals/YesOrNoDialog';
+import { inDevMode } from '../developers/inDevMode';
 
-export const LoadVolunteeringOption = ({creatorEmail, imageThumbnailURL, title, href, jobTitle, jobDescription, navTo, deleteOpportunity}) => {
+export const LoadVolunteeringOption = ({creatorEmail, imageThumbnailURL, title, href, jobTitle, jobDescription, navTo, deleteOpportunity, facebookUserSession}) => {
+
+    const userEmail = facebookUserSession ? facebookUserSession.email : "";
+    const userIsCreator = userEmail == creatorEmail || inDevMode();
 
     const [shouldShowDialog, toggleDialog] = useState(false);
 
@@ -33,9 +37,11 @@ export const LoadVolunteeringOption = ({creatorEmail, imageThumbnailURL, title, 
                     <Image field={{value: imageThumbnailURL || defaultOrgLogoSrc}} isEditMode={false} />
                 </Grid>
                 <Grid item>
-                    <PageTitle>{jobTitle} 
-                        <EditButton {...{navTo, onClick: () => alert(href)}} />
-                        <DeleteButton onClick={deleteCurrentOpportunityRequested} />
+                    <PageTitle>{jobTitle}
+                        {userIsCreator && <React.Fragment>
+                            <EditButton {...{navTo, onClick: () => alert(href)}} />
+                            <DeleteButton onClick={deleteCurrentOpportunityRequested} />
+                        </React.Fragment>}
                     </PageTitle>
                     <Space />
                     <Typography variant="h6">
@@ -51,7 +57,7 @@ export const LoadVolunteeringOption = ({creatorEmail, imageThumbnailURL, title, 
             { shouldShowDialog && 
                 <YesOrNoDialog 
                     isOpen={shouldShowDialog}
-                    titleText="Delete Volunteering Opportunity?"
+                    titleText={`Delete ${jobTitle}?`}
                     onYesClicked={confirmOppDelete}
                     onNoClicked={cancelOppDelete} />}
         </Page>

--- a/src/frontEnd/volunteering/ViewVolunteeringOption.tsx
+++ b/src/frontEnd/volunteering/ViewVolunteeringOption.tsx
@@ -8,12 +8,12 @@ import { combineOrgOppPairToSinglePropsObject } from './combineOrgOppPairToSingl
 import { WithOrganizations } from '../organizations/data/WithOrganizations';
 
 //type ViewVolunteeringOptionProps = WithNavTo & WithUrl & WithOrganizations
-export const ViewVolunteeringOption = ({url, organizations, navTo, deleteOpportunity}) => {
+export const ViewVolunteeringOption = ({url, organizations, navTo, deleteOpportunity, facebookUserSession}) => {
     const selectedJobID = (url.path).substring(14);
     const possiblyMatchingOrgVolPair = findOrgOpportunityPairByJobId(organizations, selectedJobID)
     const combinedPropsForMatch = possiblyMatchingOrgVolPair.map(combineOrgOppPairToSinglePropsObject)
     return combinedPropsForMatch.mapOrDefault(
-        combinedProps => <LoadVolunteeringOption  {...{deleteOpportunity}} {...combinedProps} {...{navTo}} />,
+        combinedProps => <LoadVolunteeringOption  {...{deleteOpportunity}} {...{facebookUserSession}} {...combinedProps} {...{navTo}} />,
         <NotFound />
     )
 }

--- a/src/frontEnd/volunteering/ViewVolunteeringOption.tsx
+++ b/src/frontEnd/volunteering/ViewVolunteeringOption.tsx
@@ -7,13 +7,13 @@ import { findOrgOpportunityPairByJobId } from './findOrgOpportunityPairByJobId';
 import { combineOrgOppPairToSinglePropsObject } from './combineOrgOppPairToSinglePropsObject';
 import { WithOrganizations } from '../organizations/data/WithOrganizations';
 
-type ViewVolunteeringOptionProps = WithNavTo & WithUrl & WithOrganizations
-export const ViewVolunteeringOption = ({url, organizations, navTo}:ViewVolunteeringOptionProps) => {
+//type ViewVolunteeringOptionProps = WithNavTo & WithUrl & WithOrganizations
+export const ViewVolunteeringOption = ({url, organizations, navTo, deleteOpportunity}) => {
     const selectedJobID = (url.path).substring(14);
     const possiblyMatchingOrgVolPair = findOrgOpportunityPairByJobId(organizations, selectedJobID)
     const combinedPropsForMatch = possiblyMatchingOrgVolPair.map(combineOrgOppPairToSinglePropsObject)
     return combinedPropsForMatch.mapOrDefault(
-        combinedProps => <LoadVolunteeringOption  {...combinedProps} {...{navTo}} />,
+        combinedProps => <LoadVolunteeringOption  {...{deleteOpportunity}} {...combinedProps} {...{navTo}} />,
         <NotFound />
     )
 }

--- a/src/frontEnd/volunteering/reducers/deleteOpportunity.ts
+++ b/src/frontEnd/volunteering/reducers/deleteOpportunity.ts
@@ -1,28 +1,17 @@
 import { navTo } from "../../nav/navTo";
 import { Organizations } from "../../organizations/data/Organizations";
-import { Organization } from "../../organizations/data/organization";
 
-export const deleteOpportunity = (state, href, jobTitle) => {
+export const deleteOpportunity = (state, jobTitle, jobID) => {
     const orgs:Organizations = state.organizations;
-
-    const orgWithOpportunityToDelete = orgs.find((org) => org.href == href);
-    if(!orgWithOpportunityToDelete){
-        throw new Error("Error")
+    const updatedState = {
+        ...state,
+        organizations: orgs.map(o => ({
+            ...o,
+            volOpportunities: o.volOpportunities.filter(v => v.jobID != jobID)
+        })),
+        shouldShowSnackbar: true,
+        snackbarText: `Opportunity ${jobTitle} Deleted`,
     }
 
-    const specifiedVolOpportunities = orgWithOpportunityToDelete.volOpportunities;
-        
-    const updatedOpportunities = specifiedVolOpportunities.filter((op) => op.jobTitle != jobTitle);
-
-    const newOrgState = {
-        ...state,
-        organizations: [
-            ...orgs,
-            orgWithOpportunityToDelete.volOpportunities = updatedOpportunities
-        ],
-        shouldShowSnackbar: true,
-        snackbarText: "Opportunity Deleted"
-    };
-
-    return navTo(newOrgState, "/");
+    return navTo(updatedState, "/");
 }

--- a/src/frontEnd/volunteering/reducers/deleteOpportunity.ts
+++ b/src/frontEnd/volunteering/reducers/deleteOpportunity.ts
@@ -10,7 +10,7 @@ export const deleteOpportunity = (state, jobTitle, jobID) => {
             volOpportunities: o.volOpportunities.filter(v => v.jobID != jobID)
         })),
         shouldShowSnackbar: true,
-        snackbarText: `Opportunity ${jobTitle} Deleted`,
+        snackbarText: `${jobTitle} Deleted`,
     }
 
     return navTo(updatedState, "/");

--- a/src/frontEnd/volunteering/reducers/deleteOpportunity.ts
+++ b/src/frontEnd/volunteering/reducers/deleteOpportunity.ts
@@ -1,0 +1,28 @@
+import { navTo } from "../../nav/navTo";
+import { Organizations } from "../../organizations/data/Organizations";
+import { Organization } from "../../organizations/data/organization";
+
+export const deleteOpportunity = (state, href, jobTitle) => {
+    const orgs:Organizations = state.organizations;
+
+    const orgWithOpportunityToDelete = orgs.find((org) => org.href == href);
+    if(!orgWithOpportunityToDelete){
+        throw new Error("Error")
+    }
+
+    const specifiedVolOpportunities = orgWithOpportunityToDelete.volOpportunities;
+        
+    const updatedOpportunities = specifiedVolOpportunities.filter((op) => op.jobTitle != jobTitle);
+
+    const newOrgState = {
+        ...state,
+        organizations: [
+            ...orgs,
+            orgWithOpportunityToDelete.volOpportunities = updatedOpportunities
+        ],
+        shouldShowSnackbar: true,
+        snackbarText: "Opportunity Deleted"
+    };
+
+    return navTo(newOrgState, "/");
+}


### PR DESCRIPTION
Can delete one opportunity without issue. Once an opportunity has been deleted,, however, trying to traverse Volunteering yields the following error:

```
EmptyList.ts:25 Uncaught TypeError: undefined is not iterable (cannot read property Symbol(Symbol.iterator))
    at ./src/utils/list/List.ts.__read (EmptyList.ts:25)
    at ./src/utils/list/List.ts.__spread (EmptyList.ts:25)
    at Object../src/utils/list/List.ts.exports.List (List.ts:4)
    at ./src/frontEnd/volunteering/orgOppPairsForSingleOrg.ts.exports.orgOppPairsForSingleOrg (orgOppPairsForSingleOrg.ts:6)
    at Object.flatMap (NonEmptyList.ts:7)
    at Object.flatMap (NonEmptyList.ts:7)
    at Object.flatMap (NonEmptyList.ts:7)
    at Object.flatMap (NonEmptyList.ts:7)
    at Object.flatMap (NonEmptyList.ts:7)
    at Object.flatMap (NonEmptyList.ts:7)
```